### PR TITLE
chore: add .gitignore to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+.metadata
+*.db
+build
+
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+*.iml
+.idea/
+
+# Other
+log/
+*.log
+bin/
+logs/
+
+# Project Specific
+testeronii.txt


### PR DESCRIPTION
A `.gitignore` allows the Git repository to ignore files & folders that are for IDE configuration or not essential to overall development of the project.