### PR TITLE
feat: envelope creation works from server (hardcoded though)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 group = 'edu.unomaha.docusign'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '16'
 
 repositories {
 	mavenCentral()

--- a/src/main/java/edu/unomaha/docusign/auth/Docusign.java
+++ b/src/main/java/edu/unomaha/docusign/auth/Docusign.java
@@ -1,10 +1,10 @@
 package edu.unomaha.docusign.auth;
 
 import com.docusign.esign.client.ApiException;
+import com.docusign.esign.model.EnvelopeDefinition;
 import edu.unomaha.docusign.docusign.DocusignEndpoint;
 import edu.unomaha.docusign.docusign.EnvelopeHandler;
 import edu.unomaha.docusign.docusign.EnvelopeResponse;
-import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.IOException;
 
@@ -21,9 +21,11 @@ public class Docusign extends ApiBinding {
         return restTemplate.getForObject(DocusignEndpoint.getBasePath() + "/envelopes?from_date=2020-01-01", EnvelopeResponse.class);
     }
 
-    public RedirectView sendEnvelope() throws IOException, ApiException {
+    public EnvelopeResponse sendEnvelope() throws IOException {
         EnvelopeHandler envelopeHandler = new EnvelopeHandler();
-        return envelopeHandler.sendEnvelope(accessToken);
+        // TODO these shouldn't be hardcoded
+        EnvelopeDefinition envelope = envelopeHandler.makeEnvelope("blakebartenbach@gmail.com", "Blake Bartenbach");
+        return restTemplate.postForObject(DocusignEndpoint.getBasePath() + "/envelopes", envelope, EnvelopeResponse.class);
     }
 
 }

--- a/src/main/java/edu/unomaha/docusign/docusign/DocusignEndpoint.java
+++ b/src/main/java/edu/unomaha/docusign/docusign/DocusignEndpoint.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.IOException;
 
@@ -16,11 +15,11 @@ public class DocusignEndpoint {
 
     private static final String AUTHENTICATION_SCOPE = "signature";
     private static final String DOCUSIGN_API_ENDPOINT = "https://account-d.docusign.com/oauth";
-    private static final String BASE_URI = "https://demo.docusign.net";
+    private static final String BASE_URI = "https://demo.docusign.net/restapi";
     private static final String REGISTRATION_ID = "docusign";
     private static final String CLIENT_ID = "5f178629-92f1-431f-a323-3b6852e823a0";
     private static final String CLIENT_SECRET = "8f02b844-499f-460f-bda9-f354f5f2ce05";
-    private static final String DOCUSIGN_API_PATH = "/restapi/2.1/accounts/";
+    private static final String DOCUSIGN_API_PATH = "/2.1/accounts/";
     private static final String ACCOUNT_ID = "55788584-a2f9-4396-8858-69844d1590d5";
 
     @Autowired
@@ -46,13 +45,15 @@ public class DocusignEndpoint {
     public String getEnvelopes() throws IOException {
         EnvelopeResponse envelopeResponse = docusign.getEnvelopes();
         if (envelopeResponse.getResultSetSize() > 0) {
-            return "You currently have " + envelopeResponse.getResultSetSize() + " envelopes";
+            String envelope = envelopeResponse.getNextUri();
+            return "You currently have an envelope:\n\t" + envelopeResponse.getNextUri();
+
         }
-        return "No envelopes found for current user";
+        return "You currently don't have any envelopes.";
     }
 
     @GetMapping("/envelopes/send")
-    public RedirectView sendEnvelope() throws IOException, ApiException {
+    public EnvelopeResponse sendEnvelope() throws IOException {
         return docusign.sendEnvelope();
     }
 

--- a/src/main/java/edu/unomaha/docusign/docusign/EnvelopeHandler.java
+++ b/src/main/java/edu/unomaha/docusign/docusign/EnvelopeHandler.java
@@ -1,12 +1,11 @@
 package edu.unomaha.docusign.docusign;
 
 import com.docusign.esign.api.EnvelopesApi;
-import com.docusign.esign.client.ApiClient;
 import com.docusign.esign.client.ApiException;
 import com.docusign.esign.model.*;
+import edu.unomaha.docusign.auth.Docusign;
 import org.springframework.web.servlet.view.RedirectView;
 
-import javax.ws.rs.core.HttpHeaders;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -14,43 +13,33 @@ import java.util.Base64;
 
 public class EnvelopeHandler {
 
-    public RedirectView sendEnvelope(String accessToken) throws IOException, ApiException {
+    public RedirectView sendEnvelope() throws IOException, ApiException {
         //TODO accept real arguments
-        String signerName = "Herbert Kerschmucketty";
+        String signerName = "Blake Bartenbach";
         String signerEmail = "blakebartenbach@gmail.com";
-
         EnvelopeDefinition envelope = makeEnvelope(signerEmail, signerName);
 
-        // create the api client object
-        ApiClient apiClient = new ApiClient(DocusignEndpoint.getBaseUri());
-        apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        System.out.println(apiClient.getBasePath());
-        apiClient.setAccessToken(accessToken, 30000L);
-        System.out.println(apiClient.getAccessToken());
-
-        // call ds to create the envelope
         EnvelopesApi envelopesApi = new EnvelopesApi();
         EnvelopeSummary envelopeSummary = envelopesApi.createEnvelope(DocusignEndpoint.getAccountId(), envelope);
         String envelopeId = envelopeSummary.getEnvelopeId();
+        System.out.println("envelope ID: " + envelopeId);
+
         RecipientViewRequest recipientViewRequest = makeRecipientViewRequest(signerEmail, signerName);
         ViewUrl viewUrl = envelopesApi.createRecipientView(DocusignEndpoint.getAccountId(), envelopeId, recipientViewRequest);
         return new RedirectView(viewUrl.getUrl());
     }
 
-    private EnvelopeDefinition makeEnvelope(String signerEmail, String signerName) throws IOException {
+    public EnvelopeDefinition makeEnvelope(String signerEmail, String signerName) throws IOException {
         String docPdf = "files/Lien Waiver Final.pdf";
         byte[] buffer = this.getFileFromResourceAsStream(docPdf).readAllBytes();
         EnvelopeDefinition envelopeDefinition = new EnvelopeDefinition();
         envelopeDefinition.setEmailSubject("Please sign this document");
         Document doc1 = new Document();
-
         String doc1b64 = new String(Base64.getEncoder().encode(buffer));
-
         doc1.setDocumentBase64(doc1b64);
         doc1.setName("Docusign Team Testing");
         doc1.setFileExtension("pdf");
         doc1.setDocumentId("3");
-
         envelopeDefinition.setDocuments(Arrays.asList(doc1));
 
         Signer signer1 = new Signer();


### PR DESCRIPTION
Upgraded to Java 16 (again) now that Gradle supports it.

I was able to send an envelope using the server - I don't know if you can do it again, but I'm opening this PR because clearly SOMETHING is right about this.  Might need to be tweaked still though.